### PR TITLE
Custom headers support in requests to WC

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -137,6 +137,11 @@ Example of returned data:
 Changelog
 ---------
 
+1.2.2 - 2018/02/05
+~~~~~~~~~~~~~~~~~~
+
+- Add custom HTTP headers support.
+
 1.2.1 - 2016/12/14
 ~~~~~~~~~~~~~~~~~~
 

--- a/tests.py
+++ b/tests.py
@@ -158,7 +158,8 @@ class WooCommerceCustomHeadersTestCase(unittest.TestCase):
             consumer_secret=consumer_secret,
             headers=headers
         )
-        self.assertDictContainsSubset(headers, api.default_headers)
+        self.assertTrue('SOME_HTTP_HEADER' in api.default_headers)
+        self.assertEqual(api.default_headers['SOME_HTTP_HEADER'], 42)
 
     def test_get_with_custom_header(self):
         """ Test GET requests """

--- a/tests.py
+++ b/tests.py
@@ -148,9 +148,9 @@ class WooCommerceCustomHeadersTestCase(unittest.TestCase):
             headers={'SOME_DEFAULT_HTTP_HEADERS': 100500}
         )
 
-    def test_api_object_should_contain_given_http_headers(self):
-        consumer_key = "ck_{}".format(40 * "X")
-        consumer_secret = "cs_{}".format(40 * "X")
+    def test_api_object_should_contain_given_http_header(self):
+        consumer_key = "ck_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+        consumer_secret = "cs_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
         headers = {'SOME_HTTP_HEADER': 42}
         api = woocommerce.API(
             url="http://woo.test",
@@ -177,7 +177,9 @@ class WooCommerceCustomHeadersTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTrue('custom_header' in response.headers)
         self.assertEqual(response.headers['custom_header'], 42)
-        self.assertEqual(self.api.default_headers['SOME_DEFAULT_HTTP_HEADERS'], 100500)
+        self.assertEqual(
+            self.api.default_headers['SOME_DEFAULT_HTTP_HEADERS'], 100500
+        )
 
     def test_post_with_custom_header(self):
         """ Test POST requests """
@@ -196,7 +198,9 @@ class WooCommerceCustomHeadersTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 201)
         self.assertTrue('custom_header' in response.headers)
         self.assertEqual(response.headers['custom_header'], 42)
-        self.assertEqual(self.api.default_headers['SOME_DEFAULT_HTTP_HEADERS'], 100500)
+        self.assertEqual(
+            self.api.default_headers['SOME_DEFAULT_HTTP_HEADERS'], 100500
+        )
 
     def test_put_with_custom_header(self):
         """ Test PUT requests """
@@ -215,7 +219,10 @@ class WooCommerceCustomHeadersTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTrue('custom_header' in response.headers)
         self.assertEqual(response.headers['custom_header'], 42)
-        self.assertEqual(self.api.default_headers['SOME_DEFAULT_HTTP_HEADERS'], 100500)
+        self.assertEqual(
+            self.api.default_headers['SOME_DEFAULT_HTTP_HEADERS'], 100500
+        )
+
 
     def test_delete_with_custom_header(self):
         """ Test DELETE requests """
@@ -234,4 +241,6 @@ class WooCommerceCustomHeadersTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTrue('custom_header' in response.headers)
         self.assertEqual(response.headers['custom_header'], 42)
-        self.assertEqual(self.api.default_headers['SOME_DEFAULT_HTTP_HEADERS'], 100500)
+        self.assertEqual(
+            self.api.default_headers['SOME_DEFAULT_HTTP_HEADERS'], 100500
+        )

--- a/tests.py
+++ b/tests.py
@@ -148,6 +148,19 @@ class WooCommerceCustomHeadersTestCase(unittest.TestCase):
             headers={'SOME_DEFAULT_HTTP_HEADERS': 100500}
         )
 
+    def test_api_object_should_changeheaders_when_given_none(self):
+        consumer_key = "ck_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+        consumer_secret = "cs_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+        api = woocommerce.API(
+            url="http://woo.test",
+            consumer_key=consumer_key,
+            consumer_secret=consumer_secret,
+            headers=None
+        )
+        self.assertEqual(len(api.headers), 2)
+        self.assertTrue("user-agent" in api.headers)
+        self.assertTrue("accept" in api.headers)
+
     def test_api_object_should_contain_given_http_header(self):
         consumer_key = "ck_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
         consumer_secret = "cs_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
@@ -158,8 +171,8 @@ class WooCommerceCustomHeadersTestCase(unittest.TestCase):
             consumer_secret=consumer_secret,
             headers=headers
         )
-        self.assertTrue('SOME_HTTP_HEADER' in api.default_headers)
-        self.assertEqual(api.default_headers['SOME_HTTP_HEADER'], 42)
+        self.assertTrue('SOME_HTTP_HEADER' in api.headers)
+        self.assertEqual(api.headers['SOME_HTTP_HEADER'], 42)
 
     def test_get_with_custom_header(self):
         """ Test GET requests """
@@ -179,7 +192,7 @@ class WooCommerceCustomHeadersTestCase(unittest.TestCase):
         self.assertTrue('custom_header' in response.headers)
         self.assertEqual(response.headers['custom_header'], 42)
         self.assertEqual(
-            self.api.default_headers['SOME_DEFAULT_HTTP_HEADERS'], 100500
+            self.api.headers['SOME_DEFAULT_HTTP_HEADERS'], 100500
         )
 
     def test_post_with_custom_header(self):
@@ -200,7 +213,7 @@ class WooCommerceCustomHeadersTestCase(unittest.TestCase):
         self.assertTrue('custom_header' in response.headers)
         self.assertEqual(response.headers['custom_header'], 42)
         self.assertEqual(
-            self.api.default_headers['SOME_DEFAULT_HTTP_HEADERS'], 100500
+            self.api.headers['SOME_DEFAULT_HTTP_HEADERS'], 100500
         )
 
     def test_put_with_custom_header(self):
@@ -221,7 +234,7 @@ class WooCommerceCustomHeadersTestCase(unittest.TestCase):
         self.assertTrue('custom_header' in response.headers)
         self.assertEqual(response.headers['custom_header'], 42)
         self.assertEqual(
-            self.api.default_headers['SOME_DEFAULT_HTTP_HEADERS'], 100500
+            self.api.headers['SOME_DEFAULT_HTTP_HEADERS'], 100500
         )
 
 
@@ -243,5 +256,5 @@ class WooCommerceCustomHeadersTestCase(unittest.TestCase):
         self.assertTrue('custom_header' in response.headers)
         self.assertEqual(response.headers['custom_header'], 42)
         self.assertEqual(
-            self.api.default_headers['SOME_DEFAULT_HTTP_HEADERS'], 100500
+            self.api.headers['SOME_DEFAULT_HTTP_HEADERS'], 100500
         )

--- a/tests.py
+++ b/tests.py
@@ -159,7 +159,7 @@ class WooCommerceCustomHeadersTestCase(unittest.TestCase):
         with HTTMock(woo_test_mock):
             # call requests
             response = self.api.get(
-                "products", custom_headers={'custom_header': 42}
+                "products", headers={'custom_header': 42}
             )
         self.assertEqual(response.status_code, 200)
         self.assertTrue('custom_header' in response.headers)
@@ -177,7 +177,7 @@ class WooCommerceCustomHeadersTestCase(unittest.TestCase):
         with HTTMock(woo_test_mock):
             # call requests
             response = self.api.post(
-                "products", {}, custom_headers={'custom_header': 42}
+                "products", {}, headers={'custom_header': 42}
             )
         self.assertEqual(response.status_code, 201)
         self.assertTrue('custom_header' in response.headers)
@@ -196,7 +196,7 @@ class WooCommerceCustomHeadersTestCase(unittest.TestCase):
         with HTTMock(woo_test_mock):
             # call requests
             response = self.api.put(
-                "products", {}, custom_headers={'custom_header': 42}
+                "products", {}, headers={'custom_header': 42}
             )
         self.assertEqual(response.status_code, 200)
         self.assertTrue('custom_header' in response.headers)
@@ -215,7 +215,7 @@ class WooCommerceCustomHeadersTestCase(unittest.TestCase):
         with HTTMock(woo_test_mock):
             # call requests
             response = self.api.delete(
-                "products", custom_headers={'custom_header': 42}
+                "products", headers={'custom_header': 42}
             )
         self.assertEqual(response.status_code, 200)
         self.assertTrue('custom_header' in response.headers)

--- a/tests.py
+++ b/tests.py
@@ -144,8 +144,21 @@ class WooCommerceCustomHeadersTestCase(unittest.TestCase):
         self.api = woocommerce.API(
             url="http://woo.test",
             consumer_key=self.consumer_key,
-            consumer_secret=self.consumer_secret
+            consumer_secret=self.consumer_secret,
+            headers={'SOME_DEFAULT_HTTP_HEADERS': 100500}
         )
+
+    def test_api_object_should_contain_given_http_headers(self):
+        consumer_key = "ck_{}".format(40 * "X")
+        consumer_secret = "cs_{}".format(40 * "X")
+        headers = {'SOME_HTTP_HEADER': 42}
+        api = woocommerce.API(
+            url="http://woo.test",
+            consumer_key=consumer_key,
+            consumer_secret=consumer_secret,
+            headers=headers
+        )
+        self.assertDictContainsSubset(headers, api.default_headers)
 
     def test_get_with_custom_header(self):
         """ Test GET requests """
@@ -164,6 +177,7 @@ class WooCommerceCustomHeadersTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTrue('custom_header' in response.headers)
         self.assertEqual(response.headers['custom_header'], 42)
+        self.assertEqual(self.api.default_headers['SOME_DEFAULT_HTTP_HEADERS'], 100500)
 
     def test_post_with_custom_header(self):
         """ Test POST requests """
@@ -182,7 +196,7 @@ class WooCommerceCustomHeadersTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 201)
         self.assertTrue('custom_header' in response.headers)
         self.assertEqual(response.headers['custom_header'], 42)
-
+        self.assertEqual(self.api.default_headers['SOME_DEFAULT_HTTP_HEADERS'], 100500)
 
     def test_put_with_custom_header(self):
         """ Test PUT requests """
@@ -201,7 +215,7 @@ class WooCommerceCustomHeadersTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTrue('custom_header' in response.headers)
         self.assertEqual(response.headers['custom_header'], 42)
-
+        self.assertEqual(self.api.default_headers['SOME_DEFAULT_HTTP_HEADERS'], 100500)
 
     def test_delete_with_custom_header(self):
         """ Test DELETE requests """
@@ -220,4 +234,4 @@ class WooCommerceCustomHeadersTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTrue('custom_header' in response.headers)
         self.assertEqual(response.headers['custom_header'], 42)
-
+        self.assertEqual(self.api.default_headers['SOME_DEFAULT_HTTP_HEADERS'], 100500)

--- a/tests.py
+++ b/tests.py
@@ -134,3 +134,90 @@ class WooCommerceTestCase(unittest.TestCase):
         check_sorted(['a', 'b[c]', 'b[a]', 'b[b]', 'c'], ['a', 'b[c]', 'b[a]', 'b[b]', 'c'])
         check_sorted(['d', 'b[c]', 'b[a]', 'b[b]', 'c'], ['b[c]', 'b[a]', 'b[b]', 'c', 'd'])
         check_sorted(['a1', 'b[c]', 'b[a]', 'b[b]', 'a2'], ['a1', 'a2', 'b[c]', 'b[a]', 'b[b]'])
+
+
+class WooCommerceCustomHeadersTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.consumer_key = "ck_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+        self.consumer_secret = "cs_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+        self.api = woocommerce.API(
+            url="http://woo.test",
+            consumer_key=self.consumer_key,
+            consumer_secret=self.consumer_secret
+        )
+
+    def test_get_with_custom_header(self):
+        """ Test GET requests """
+        @all_requests
+        def woo_test_mock(*args, **kwargs):
+            """ URL Mock """
+            return {'status_code': 200,
+                    'content': 'OK',
+                    'headers': dict(args[1].headers)}
+
+        with HTTMock(woo_test_mock):
+            # call requests
+            response = self.api.get(
+                "products", custom_headers={'custom_header': 42}
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue('custom_header' in response.headers)
+        self.assertEqual(response.headers['custom_header'], 42)
+
+    def test_post_with_custom_header(self):
+        """ Test POST requests """
+        @all_requests
+        def woo_test_mock(*args, **kwargs):
+            """ URL Mock """
+            return {'status_code': 201,
+                    'content': 'OK',
+                    'headers': dict(args[1].headers)}
+
+        with HTTMock(woo_test_mock):
+            # call requests
+            response = self.api.post(
+                "products", {}, custom_headers={'custom_header': 42}
+            )
+        self.assertEqual(response.status_code, 201)
+        self.assertTrue('custom_header' in response.headers)
+        self.assertEqual(response.headers['custom_header'], 42)
+
+
+    def test_put_with_custom_header(self):
+        """ Test PUT requests """
+        @all_requests
+        def woo_test_mock(*args, **kwargs):
+            """ URL Mock """
+            return {'status_code': 200,
+                    'content': 'OK',
+                    'headers': dict(args[1].headers)}
+
+        with HTTMock(woo_test_mock):
+            # call requests
+            response = self.api.put(
+                "products", {}, custom_headers={'custom_header': 42}
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue('custom_header' in response.headers)
+        self.assertEqual(response.headers['custom_header'], 42)
+
+
+    def test_delete_with_custom_header(self):
+        """ Test DELETE requests """
+        @all_requests
+        def woo_test_mock(*args, **kwargs):
+            """ URL Mock """
+            return {'status_code': 200,
+                    'content': 'OK',
+                    'headers': dict(args[1].headers)}
+
+        with HTTMock(woo_test_mock):
+            # call requests
+            response = self.api.delete(
+                "products", custom_headers={'custom_header': 42}
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue('custom_header' in response.headers)
+        self.assertEqual(response.headers['custom_header'], 42)
+

--- a/woocommerce/__init__.py
+++ b/woocommerce/__init__.py
@@ -10,7 +10,7 @@ A Python wrapper for WooCommerce API.
 """
 
 __title__ = "woocommerce"
-__version__ = "1.2.1"
+__version__ = "1.2.2"
 __author__ = "Claudio Sanches @ WooThemes"
 __license__ = "MIT"
 

--- a/woocommerce/api.py
+++ b/woocommerce/api.py
@@ -13,6 +13,11 @@ from requests import request
 from json import dumps as jsonencode
 from woocommerce.oauth import OAuth
 
+DEFAULT_HEADERS = {
+    "user-agent": "WooCommerce API Client-Python/%s" % __version__,
+    "accept": "application/json"
+}
+
 
 class API(object):
     """ API Class """
@@ -27,6 +32,14 @@ class API(object):
         self.timeout = kwargs.get("timeout", 5)
         self.verify_ssl = kwargs.get("verify_ssl", True)
         self.query_string_auth = kwargs.get("query_string_auth", False)
+        self.default_headers = dict(
+            DEFAULT_HEADERS.items(), **kwargs.get("headers", {})
+        )
+
+    def __create_headers(self, headers):
+        if headers is not None:
+            return dict(self.default_headers.items(), **headers)
+        return self.default_headers
 
     def __is_ssl(self):
         """ Check if url use HTTPS """
@@ -62,13 +75,7 @@ class API(object):
         url = self.__get_url(endpoint)
         auth = None
         params = {}
-        headers = {
-            "user-agent": "WooCommerce API Client-Python/%s" % __version__,
-            "accept": "application/json"
-        }
-
-        if custom_headers is not None:
-            headers.update(custom_headers)
+        headers = self.__create_headers(custom_headers)
 
         if self.is_ssl is True and self.query_string_auth is False:
             auth = (self.consumer_key, self.consumer_secret)

--- a/woocommerce/api.py
+++ b/woocommerce/api.py
@@ -95,22 +95,22 @@ class API(object):
             headers=headers
         )
 
-    def get(self, endpoint, custom_headers=None):
+    def get(self, endpoint, headers=None):
         """ Get requests """
-        return self.__request("GET", endpoint, None, custom_headers)
+        return self.__request("GET", endpoint, None, headers)
 
-    def post(self, endpoint, data, custom_headers=None):
+    def post(self, endpoint, data, headers=None):
         """ POST requests """
-        return self.__request("POST", endpoint, data, custom_headers)
+        return self.__request("POST", endpoint, data, headers)
 
-    def put(self, endpoint, data, custom_headers=None):
+    def put(self, endpoint, data, headers=None):
         """ PUT requests """
-        return self.__request("PUT", endpoint, data, custom_headers)
+        return self.__request("PUT", endpoint, data, headers)
 
-    def delete(self, endpoint, custom_headers=None):
+    def delete(self, endpoint, headers=None):
         """ DELETE requests """
-        return self.__request("DELETE", endpoint, None, custom_headers)
+        return self.__request("DELETE", endpoint, None, headers)
 
-    def options(self, endpoint, custom_headers=None):
+    def options(self, endpoint, headers=None):
         """ OPTIONS requests """
-        return self.__request("OPTIONS", endpoint, None, custom_headers)
+        return self.__request("OPTIONS", endpoint, None, headers)

--- a/woocommerce/api.py
+++ b/woocommerce/api.py
@@ -57,7 +57,7 @@ class API(object):
 
         return oauth.get_oauth_url()
 
-    def __request(self, method, endpoint, data):
+    def __request(self, method, endpoint, data, custom_headers=None):
         """ Do requests """
         url = self.__get_url(endpoint)
         auth = None
@@ -66,6 +66,9 @@ class API(object):
             "user-agent": "WooCommerce API Client-Python/%s" % __version__,
             "accept": "application/json"
         }
+
+        if custom_headers is not None:
+            headers.update(custom_headers)
 
         if self.is_ssl is True and self.query_string_auth is False:
             auth = (self.consumer_key, self.consumer_secret)
@@ -92,22 +95,22 @@ class API(object):
             headers=headers
         )
 
-    def get(self, endpoint):
+    def get(self, endpoint, custom_headers=None):
         """ Get requests """
-        return self.__request("GET", endpoint, None)
+        return self.__request("GET", endpoint, None, custom_headers)
 
-    def post(self, endpoint, data):
+    def post(self, endpoint, data, custom_headers=None):
         """ POST requests """
-        return self.__request("POST", endpoint, data)
+        return self.__request("POST", endpoint, data, custom_headers)
 
-    def put(self, endpoint, data):
+    def put(self, endpoint, data, custom_headers=None):
         """ PUT requests """
-        return self.__request("PUT", endpoint, data)
+        return self.__request("PUT", endpoint, data, custom_headers)
 
-    def delete(self, endpoint):
+    def delete(self, endpoint, custom_headers=None):
         """ DELETE requests """
-        return self.__request("DELETE", endpoint, None)
+        return self.__request("DELETE", endpoint, None, custom_headers)
 
-    def options(self, endpoint):
+    def options(self, endpoint, custom_headers=None):
         """ OPTIONS requests """
-        return self.__request("OPTIONS", endpoint, None)
+        return self.__request("OPTIONS", endpoint, None, custom_headers)

--- a/woocommerce/api.py
+++ b/woocommerce/api.py
@@ -32,14 +32,13 @@ class API(object):
         self.timeout = kwargs.get("timeout", 5)
         self.verify_ssl = kwargs.get("verify_ssl", True)
         self.query_string_auth = kwargs.get("query_string_auth", False)
-        self.default_headers = dict(
-            DEFAULT_HEADERS.items(), **kwargs.get("headers", {})
-        )
+        headers = kwargs.get("headers") or {}
+        self._default_headers = dict(DEFAULT_HEADERS.items(), **headers)
 
     def __create_headers(self, headers):
         if headers is not None:
-            return dict(self.default_headers.items(), **headers)
-        return self.default_headers
+            return dict(self._default_headers.items(), **headers)
+        return self._default_headers
 
     def __is_ssl(self):
         """ Check if url use HTTPS """
@@ -101,6 +100,10 @@ class API(object):
             timeout=self.timeout,
             headers=headers
         )
+
+    @property
+    def headers(self):
+        return self._default_headers
 
     def get(self, endpoint, headers=None):
         """ Get requests """


### PR DESCRIPTION
I've noticed a use case when you'd want to be able to add custom headers to your HTTP request. So far I needed to use **Host** HTTP header, but that was not possible with the current implementation of the library. So I think that this ability is worth to have in the code.

P.S. I've also added the ability to have a set of default headers in API object constructor. I think it does make sense because in this case you may create an object with pre-defined headers and just use it, but in case of urgent necessity you can change existent or add additional headers while sending particular requests.