### PR TITLE
api accepts url params and additional keyword args for requests module

### DIFF
--- a/woocommerce/api.py
+++ b/woocommerce/api.py
@@ -57,11 +57,12 @@ class API(object):
 
         return oauth.get_oauth_url()
 
-    def __request(self, method, endpoint, data):
+    def __request(self, method, endpoint, data, params: dict=None, **kwargs):
         """ Do requests """
+        if params is None:
+            params = {}
         url = self.__get_url(endpoint)
         auth = None
-        params = {}
         headers = {
             "user-agent": "WooCommerce API Client-Python/%s" % __version__,
             "accept": "application/json"
@@ -70,10 +71,10 @@ class API(object):
         if self.is_ssl is True and self.query_string_auth is False:
             auth = (self.consumer_key, self.consumer_secret)
         elif self.is_ssl is True and self.query_string_auth is True:
-            params = {
+            params.update({
                 "consumer_key": self.consumer_key,
                 "consumer_secret": self.consumer_secret
-            }
+            })
         else:
             url = self.__get_oauth_url(url, method)
 
@@ -89,25 +90,26 @@ class API(object):
             params=params,
             data=data,
             timeout=self.timeout,
-            headers=headers
+            headers=headers,
+            **kwargs
         )
 
-    def get(self, endpoint):
+    def get(self, endpoint, **kwargs):
         """ Get requests """
-        return self.__request("GET", endpoint, None)
+        return self.__request("GET", endpoint, None, **kwargs)
 
-    def post(self, endpoint, data):
+    def post(self, endpoint, data, **kwargs):
         """ POST requests """
-        return self.__request("POST", endpoint, data)
+        return self.__request("POST", endpoint, data, **kwargs)
 
-    def put(self, endpoint, data):
+    def put(self, endpoint, data, **kwargs):
         """ PUT requests """
-        return self.__request("PUT", endpoint, data)
+        return self.__request("PUT", endpoint, data, **kwargs)
 
-    def delete(self, endpoint):
+    def delete(self, endpoint, **kwargs):
         """ DELETE requests """
-        return self.__request("DELETE", endpoint, None)
+        return self.__request("DELETE", endpoint, None, **kwargs)
 
-    def options(self, endpoint):
+    def options(self, endpoint, **kwargs):
         """ OPTIONS requests """
-        return self.__request("OPTIONS", endpoint, None)
+        return self.__request("OPTIONS", endpoint, None, **kwargs)


### PR DESCRIPTION
Currently the url params that are sent to Woo-Commerce are a closed box.
They should be exposed outside of the function. Additionally, there are
cases where a developer needs to pass additional parameters to the
requests library. These should also be exposed outside of the function.

I've been meaning to make a pull request for this. I have previously 
sub-classed the woocommerce.api.API object in order to do this and
think it would be helpful to others who like me need to do more 
complicated requests.